### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: h-sanity
+  title: H-Sanity Universidad
+  description: Sistema de informacion para gestion de auditorias de sanidad
+  annotations:
+    github.com/project-slug: Ludwinghc/H-Sanity
+
+    backstage.io/techdocs-ref: dir:.
+
+    backstage.io/source-location: url:https://github.com/Ludwinghc/H-Sanity/tree/master/
+  tags:
+
+
+    - backstage
+
+    - python
+
+
+spec:
+  type: website
+  lifecycle: production
+  owner: user:default/ludwinghc


### PR DESCRIPTION
Este Pull Request agrega el archivo catalog-info.yaml para registrar este repositorio en Backstage.

Incluye:
- Metadata estándar del componente
- Annotation github.com/project-slug
- Annotation backstage.io/source-location
- Tags técnicos
- Owner
- Lifecycle
- Tipo de componente

Después de hacer merge, GitHub Discovery debería detectar automáticamente esta entidad.
